### PR TITLE
fix(swoole): Make swoole http server lazy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "symfony/framework-bundle": "^4.0",
     "symfony/lts": "^4@dev",
     "symfony/monolog-bundle": "^3.2",
+    "symfony/proxy-manager-bridge": "^4.0",
     "symfony/yaml": "^4.0",
     "vich/uploader-bundle": "^1.8",
     "webonyx/graphql-php": "^0.12"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d92f2a21d459762456551a331246455",
+    "content-hash": "48c59607ace480dc731a602b5ea075e2",
     "packages": [
         {
             "name": "api-platform/api-pack",
@@ -4921,6 +4921,60 @@
                 "validator"
             ],
             "time": "2018-05-16T14:33:22+00:00"
+        },
+        {
+            "name": "symfony/proxy-manager-bridge",
+            "version": "v4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/proxy-manager-bridge.git",
+                "reference": "50a425f6242ed85ba1055ac654f5fbc87392365d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/proxy-manager-bridge/zipball/50a425f6242ed85ba1055ac654f5fbc87392365d",
+                "reference": "50a425f6242ed85ba1055ac654f5fbc87392365d",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
+                "php": "^7.1.3",
+                "symfony/dependency-injection": "~3.4|~4.0"
+            },
+            "require-dev": {
+                "symfony/config": "~3.4|~4.0"
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\ProxyManager\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ProxyManager Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-22T11:40:25+00:00"
         },
         {
             "name": "symfony/routing",

--- a/src/Bundle/SwooleBundle/Resources/config/services.yaml
+++ b/src/Bundle/SwooleBundle/Resources/config/services.yaml
@@ -43,6 +43,7 @@ services:
     'App\Bundle\SwooleBundle\Driver\LimitedHttpDriver':
 
     'Swoole\Http\Server':
+        lazy: true
 
     'App\Bundle\SwooleBundle\Command\ServerRunCommand':
         tags: ['console.command']

--- a/symfony.lock
+++ b/symfony.lock
@@ -497,6 +497,9 @@
     "symfony/property-info": {
         "version": "v3.3.10"
     },
+    "symfony/proxy-manager-bridge": {
+        "version": "v4.1.0"
+    },
     "symfony/routing": {
         "version": "3.3",
         "recipe": {


### PR DESCRIPTION
When swoole server was running (e.g. in docker container), trying to execute any commands resulted
in creation of new swoole http server instance, which leads to an error due to port allocation