### PR TITLE
build(docker): Improve standalone build (with API Admin)

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -3,17 +3,26 @@ ARG KNIT_API_ADMIN_TAG
 
 FROM knitpk/api-admin:${KNIT_API_ADMIN_TAG} as api-admin
 
-ARG KNIT_API_URL
-RUN REACT_APP_API_URL=$KNIT_API_URL yarn build
+ARG KNTI_API_ADMIN_PUBLIC_URL='/admin'
+ARG KNIT_API_ADMIN_API_URL='http://localhost'
+ENV PUBLIC_URL=${KNTI_API_ADMIN_PUBLIC_URL} \
+    REACT_APP_API_URL=${KNIT_API_ADMIN_API_URL}
+
+RUN ASSETS_VERSION=$(cat build/asset-manifest.json | grep "\"main.js\"" | sed -E "s/\s+\"main.js\": \"static\/js\/main\.(.*)\.js\",/\1/") && \
+    dockerize -delims "{{{:}}}" \
+      -template build/index.html.tmpl:build/index.html \
+      -template build/service-worker.js.tmpl:build/service-worker.js \
+      -template build/static/js/main.$ASSETS_VERSION.js.tmpl:build/static/js/main.$ASSETS_VERSION.js \
+      -template build/static/js/main.$ASSETS_VERSION.js.map.tmpl:build/static/js/main.$ASSETS_VERSION.js.map
+
 
 FROM knitpk/api:${KNIT_API_TAG}
 
-ENV NGINX_PORT 80
-
 RUN apk add --no-cache nginx
-
 COPY deploy/standalone/nginx.conf /etc/nginx/nginx.conf
 COPY deploy/standalone/default.conf /etc/nginx/conf.d/default.conf
 COPY deploy/standalone/docker-app-entrypoint.sh /usr/local/bin/docker-app-entrypoint
 RUN chmod +x /usr/local/bin/docker-app-entrypoint
-COPY --from=api-admin /usr/src/app/build /usr/src/api/public/admin
+COPY --from=api-admin /usr/src/app/build /usr/src/api/public/adminos
+
+ENV NGINX_PORT 80

--- a/deploy/docker-app-push.sh
+++ b/deploy/docker-app-push.sh
@@ -22,7 +22,8 @@ docker build -f Dockerfile.standalone . \
     --tag knitpk/api:standalone \
     --build-arg KNIT_API_TAG=${DOCKER_TAG} \
     --build-arg KNIT_API_ADMIN_TAG=latest \
-    --build-arg KNIT_API_URL=https://d15e2ckuuchn46.cloudfront.net
+    --build-arg KNTI_API_ADMIN_PUBLIC_URL=/admin \
+    --build-arg KNIT_API_ADMIN_API_URL=https://d15e2ckuuchn46.cloudfront.net
 
 docker push knitpk/api:${DOCKER_TAG}-standalone
 docker push knitpk/api:standalone

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,9 @@ services:
     nginx:
         build:
             context: ./docker/nginx
+            args:
+                - ADMIN_PUBLIC_URL='/admin'
+                - ADMIN_API_URL='http://localhost'
         depends_on:
             - api
         environment:
@@ -61,31 +64,32 @@ services:
             - './vendor:/usr/src/api/vendor'
             - '/usr/src/api/public/admin'
 
-#    standalone:
-#        image: knitpk/api:standalone
-#        depends_on:
-#            - mysql
-#            - redis
-#        build:
-#            dockerfile: Dockerfile.standalone
-#            context: .
-#            cache_from:
-#                - knitpk/api:standalone
-#            args:
-#                - KNIT_API_TAG=latest
-#                - KNIT_API_ADMIN_TAG=latest
-#                - 'KNIT_API_URL=http://localhost'
-#        env_file: .env.dev
-#        environment:
-#            - PORT=9501
-#            - NGINX_PORT=8899
-#        volumes:
-#            - '.:/usr/src/api'
-#            - /usr/src/api/var
-#            - /usr/src/api/public/admin
-#            - 'composer_cache:/root/.composer'
-#        ports:
-#            - '8300:8899'
+    # standalone:
+    #     image: knitpk/api:standalone
+    #     depends_on:
+    #         - mysql
+    #         - redis
+    #     build:
+    #         dockerfile: Dockerfile.standalone
+    #         context: .
+    #         cache_from:
+    #             - knitpk/api:standalone
+    #         args:
+    #             - KNIT_API_TAG=latest
+    #             - KNIT_API_ADMIN_TAG=latest
+    #             - 'KNTI_API_ADMIN_PUBLIC_URL=/admin'
+    #             - 'KNIT_API_ADMIN_API_URL=http://localhost:8300'
+    #     env_file: .env.dev
+    #     environment:
+    #         - PORT=9501
+    #         - NGINX_PORT=8899
+    #     volumes:
+    #         - '.:/usr/src/api'
+    #         - /usr/src/api/var
+    #         - /usr/src/api/public/adminos
+    #         - 'composer_cache:/root/.composer'
+    #     ports:
+    #         - '8300:8899'
 
     varnish:
         depends_on:

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,7 +1,17 @@
 FROM knitpk/api-admin:latest as api-admin
 
-ARG KNIT_API_URL=http://localhost
-RUN REACT_APP_API_URL=$KNIT_API_URL yarn build
+ARG ADMIN_PUBLIC_URL='/admin'
+ARG ADMIN_API_URL='http://localhost'
+ENV PUBLIC_URL=${ADMIN_PUBLIC_URL} \
+    REACT_APP_API_URL=${ADMIN_API_URL}
+
+RUN ASSETS_VERSION=$(cat build/asset-manifest.json | grep "\"main.js\"" | sed -E "s/\s+\"main.js\": \"static\/js\/main\.(.*)\.js\",/\1/") && \
+    dockerize -delims "{{{:}}}" \
+      -template build/index.html.tmpl:build/index.html \
+      -template build/service-worker.js.tmpl:build/service-worker.js \
+      -template build/static/js/main.$ASSETS_VERSION.js.tmpl:build/static/js/main.$ASSETS_VERSION.js \
+      -template build/static/js/main.$ASSETS_VERSION.js.map.tmpl:build/static/js/main.$ASSETS_VERSION.js.map
+
 
 FROM alpine:3.7
 

--- a/docker/varnish/conf/default.vcl
+++ b/docker/varnish/conf/default.vcl
@@ -13,6 +13,7 @@ acl ban {
     "localhost";
     "127.0.0.1";
     "api";
+    // "standalone";
 }
 
 sub vcl_backend_response {
@@ -38,7 +39,7 @@ sub vcl_deliver {
 
     // CORS
     set req.http.Access-Control-Allow-Origin = "*";
-    
+
     // Insert Diagnostic header to show Hit or Miss
     if (obj.hits > 0) {
         set resp.http.X-Cache = "Hits: " + obj.hits;


### PR DESCRIPTION
Instead of rebuilding assets via react-scripts use dockerize templates

Needs: https://github.com/knit-pk/api-admin-v1-reactjs/pull/37