### PR TITLE
feat(serializer): Inject constructed Uuid object to newly created resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
     - APP_DEBUG=1
     - COMPOSER_METHOD=install
     - SWOOLE_VERSION=4.0.1
+    - JWT_PRIVATE_KEY_PATH=config/jwt/private.pem
+    - JWT_PUBLIC_KEY_PATH=config/jwt/public.pem
+    - JWT_PASSPHRASE=56c247d4c281f5de0d8d9d894f2b605157fd379c
 matrix:
   include:
     - php: '7.2'
@@ -67,6 +70,7 @@ script:
   - composer test
   - 'if [[ -v DATABASE_URL ]]; then bin/console doctrine:schema:create; fi'
   - 'if [[ -v DATABASE_URL ]]; then bin/console doctrine:fixtures:load -n; fi'
+  - 'if [[ -v DATABASE_URL ]]; then make generate-jwt-keys; fi'
   - 'if [[ -v DATABASE_URL ]]; then composer test-features -n; fi'
 
 before_deploy:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -86,6 +86,11 @@ services:
         arguments: [ '@App\Serializer\AdminContextBuilder.inner' ]
         autoconfigure: false
 
+    'App\Serializer\UuidContextBuilder':
+        decorates: 'api_platform.serializer.context_builder'
+        arguments: [ '@App\Serializer\UuidContextBuilder.inner' ]
+        autoconfigure: false
+
     'App\Metadata\Property\Factory\AdminPropertyMetadataFactory':
         decorates: 'api_platform.metadata.property.metadata_factory'
         decoration_priority: -20

--- a/features/crud.feature
+++ b/features/crud.feature
@@ -1,0 +1,41 @@
+Feature:
+    In order to get resources that match my criteria
+    As a client software developer
+    I want to filter resource collections by their attributes
+
+    Scenario: It should be possible to get a collection of tags
+        Given I am authenticated
+        And I add 'Accept' header equal to 'application/json'
+        When I send a 'GET' request to '/tags'
+        Then the response status code should be 200
+        And the response should be in JSON
+
+    Scenario: It should be possible to create a tag
+        Given I am authenticated
+        And I add 'Content-Type' header equal to 'application/json'
+        And I add 'Accept' header equal to 'application/json'
+        When I send a 'POST' request to '/tags' with body:
+        """
+        {
+            "name": "Dummy Tag"
+        }
+        """
+        Then the response status code should be 201
+        And the response should be in JSON
+        And the JSON node 'name' should be equal to 'Dummy Tag'
+        And the JSON node 'id' should be a valid uuid
+
+    Scenario: It should not be possible to create a tag with id
+        Given I am authenticated
+        And I add 'Content-Type' header equal to 'application/json'
+        And I add 'Accept' header equal to 'application/json'
+        When I send a 'POST' request to '/tags' with body:
+        """
+        {
+            "id": "dummy-id",
+            "name": "Dummy Tag"
+        }
+        """
+        Then the response status code should be 400
+        And the JSON node 'title' should be equal to 'An error occurred'
+        And the JSON node 'detail' should be equal to 'Update is not allowed for this operation.'

--- a/src/Action/Image/ImageUploadAction.php
+++ b/src/Action/Image/ImageUploadAction.php
@@ -6,6 +6,7 @@ namespace App\Action\Image;
 
 use App\Entity\Image;
 use App\Security\UserProvider\UserEntityProvider;
+use Ramsey\Uuid\Uuid;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -50,6 +51,6 @@ final class ImageUploadAction
             throw new HttpException(400, 'Field `image` is required, and must be a file');
         }
 
-        return Image::fromFile($imageFile, $this->userEntityProvider->getReference($user));
+        return Image::fromFile(Uuid::uuid4(), $imageFile, $this->userEntityProvider->getReference($user));
     }
 }

--- a/src/DataFixtures/ORM/ArticleFixtures.php
+++ b/src/DataFixtures/ORM/ArticleFixtures.php
@@ -12,6 +12,7 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Gedmo\Sluggable\Util\Urlizer;
 use Generator;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
@@ -35,7 +36,7 @@ class ArticleFixtures extends Fixture implements DependentFixtureInterface
     {
         // Predefined articles
         foreach ($this->getArticleFixtures() as $fixture) {
-            $article = new Article();
+            $article = new Article(Uuid::uuid4());
             if (isset($fixture['image'])) {
                 /** @var \App\Entity\Image $image */
                 $image = $this->getReference($fixture['image']);
@@ -67,7 +68,7 @@ class ArticleFixtures extends Fixture implements DependentFixtureInterface
                 /** @var array[] $comments */
                 $comments = $fixture['comments'];
                 foreach ($comments as $commentFixture) {
-                    $comment = new Comment();
+                    $comment = new Comment(Uuid::uuid4());
                     /** @var \App\Entity\User $commentAuthor */
                     $commentAuthor = $this->getReference($commentFixture['author']);
                     $comment->setAuthor($commentAuthor);
@@ -78,7 +79,7 @@ class ArticleFixtures extends Fixture implements DependentFixtureInterface
                         /** @var array[] $replies */
                         $replies = $commentFixture['replies'];
                         foreach ($replies as $replyData) {
-                            $reply = new CommentReply();
+                            $reply = new CommentReply(Uuid::uuid4());
                             /** @var \App\Entity\User $replyAuthor */
                             $replyAuthor = $this->getReference($replyData['author']);
                             $reply->setText($replyData['text']);

--- a/src/DataFixtures/ORM/CategoryFixtures.php
+++ b/src/DataFixtures/ORM/CategoryFixtures.php
@@ -11,6 +11,7 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Generator;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Yaml\Yaml;
 
 class CategoryFixtures extends Fixture implements DependentFixtureInterface
@@ -25,7 +26,7 @@ class CategoryFixtures extends Fixture implements DependentFixtureInterface
     public function load(ObjectManager $manager): void
     {
         foreach ($this->getCategoryFixtures() as $fixture) {
-            $category = new Category();
+            $category = new Category(Uuid::uuid4());
             $category->setName($fixture['name']);
             $category->setDescription($fixture['description']);
             $category->setOverlayColor($fixture['overlayColor']);

--- a/src/DataFixtures/ORM/ImageFixtures.php
+++ b/src/DataFixtures/ORM/ImageFixtures.php
@@ -8,6 +8,7 @@ use App\Entity\Image;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Generator;
+use Ramsey\Uuid\Uuid;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -53,9 +54,9 @@ class ImageFixtures extends Fixture
                 $this->filesystem->copy($imageFile->getRealPath(), $tempFile, true);
 
                 $file = new UploadedFile($tempFile, $fixture['name'], null, null, true);
-                $image = Image::fromFile($file);
+                $image = Image::fromFile(Uuid::uuid4(), $file);
             } else {
-                $image = new Image();
+                $image = new Image(Uuid::uuid4());
                 $image->setOriginalName($fixture['name']);
                 $image->setUrl($fixture['url']);
             }

--- a/src/DataFixtures/ORM/ProjectFixtures.php
+++ b/src/DataFixtures/ORM/ProjectFixtures.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
+use Ramsey\Uuid\Uuid;
 
 class ProjectFixtures extends Fixture implements DependentFixtureInterface
 {
@@ -25,7 +26,7 @@ class ProjectFixtures extends Fixture implements DependentFixtureInterface
         for ($i = 1; $i <= 10; ++$i) {
             $name = \sprintf('Project %d', $i);
 
-            $project = new Project();
+            $project = new Project(Uuid::uuid4());
             $project->setName($name);
             $project->setDescription(\sprintf('Fantastic %s description.', $name));
             $project->setAuthor($author);

--- a/src/DataFixtures/ORM/SecurityRoleFixtures.php
+++ b/src/DataFixtures/ORM/SecurityRoleFixtures.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Generator;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Yaml\Yaml;
 
 class SecurityRoleFixtures extends Fixture
@@ -25,7 +26,7 @@ class SecurityRoleFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         foreach ($this->getSecurityRoleFixtures() as $fixture) {
-            $securityRole = new SecurityRole($fixture['role']);
+            $securityRole = new SecurityRole(Uuid::uuid4(), $fixture['role']);
             $securityRole->setName($fixture['name']);
 
             if ($fixture['public']) {

--- a/src/DataFixtures/ORM/TagFixtures.php
+++ b/src/DataFixtures/ORM/TagFixtures.php
@@ -8,6 +8,7 @@ use App\Entity\Tag;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Generator;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Yaml\Yaml;
 
 class TagFixtures extends Fixture
@@ -24,7 +25,7 @@ class TagFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         foreach ($this->getTagFixtures() as $fixture) {
-            $tag = new Tag();
+            $tag = new Tag(Uuid::uuid4());
             $tag->setName($fixture['name']);
 
             if ($fixture['public']) {

--- a/src/DataFixtures/ORM/UserFixtures.php
+++ b/src/DataFixtures/ORM/UserFixtures.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Generator;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Yaml\Yaml;
 
 class UserFixtures extends Fixture implements DependentFixtureInterface
@@ -35,7 +36,7 @@ class UserFixtures extends Fixture implements DependentFixtureInterface
     {
         foreach ($this->getUserFixtures() as $fixture) {
             $username = $fixture['username'];
-            $user = new User();
+            $user = new User(Uuid::uuid4());
 
             $user->setFullname($fixture['fullname']);
             $user->setUsername($username);

--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -65,7 +65,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Article implements ThoughtfulInterface
 {
     /**
-     * @var \Ramsey\Uuid\UuidInterface
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
@@ -263,9 +263,9 @@ class Article implements ThoughtfulInterface
      */
     protected $createdAt;
 
-    public function __construct()
+    public function __construct(UuidInterface $id)
     {
-        $this->id = Uuid::uuid4();
+        $this->id = $id;
         $this->tags = new ArrayCollection();
         $this->comments = new ArrayCollection();
         $this->ratings = new ArrayCollection();

--- a/src/Entity/Category.php
+++ b/src/Entity/Category.php
@@ -48,7 +48,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Category
 {
     /**
-     * @var \Ramsey\Uuid\UuidInterface
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
@@ -162,9 +162,9 @@ class Category
      */
     protected $overlayColor;
 
-    public function __construct()
+    public function __construct(UuidInterface $id)
     {
-        $this->id = Uuid::uuid4();
+        $this->id = $id;
         $this->articlesCount = 0;
     }
 

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -64,12 +65,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Comment implements ThoughtInterface, ThoughtfulInterface
 {
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      *
      * @Groups({"CommentRead"})
      */
@@ -152,12 +151,13 @@ class Comment implements ThoughtInterface, ThoughtfulInterface
      */
     protected $createdAt;
 
-    public function __construct()
+    public function __construct(UuidInterface $id)
     {
+        $this->id = $id;
         $this->replies = new ArrayCollection();
     }
 
-    public function getId(): Uuid
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Entity/CommentReply.php
+++ b/src/Entity/CommentReply.php
@@ -13,6 +13,7 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -62,12 +63,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class CommentReply implements ThoughtInterface
 {
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      *
      * @Groups({"ReplyRead"})
      */
@@ -141,7 +140,12 @@ class CommentReply implements ThoughtInterface
      */
     protected $createdAt;
 
-    public function getId(): Uuid
+    public function __construct(UuidInterface $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -12,6 +12,7 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -68,12 +69,10 @@ class Image
     ];
 
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      *
      * @Groups({"ImageRead"})
      */
@@ -170,7 +169,12 @@ class Image
      */
     protected $createdAt;
 
-    public function getId(): ?Uuid
+    public function __construct(UuidInterface $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): UuidInterface
     {
         return $this->id;
     }
@@ -268,16 +272,17 @@ class Image
     }
 
     /**
+     * @param UuidInterface                               $id
      * @param \Symfony\Component\HttpFoundation\File\File $file
      * @param \App\Entity\User|null                       $author
      *
      * @return \App\Entity\Image
      */
-    public static function fromFile(File $file, ?User $author = null): self
+    public static function fromFile(UuidInterface $id, File $file, ?User $author = null): self
     {
         Assertion::inArray($file->getMimeType(), self::SUPPORTED_MIME_TYPES, 'Given file mime type "%s" is not among supported: %s');
 
-        $image = new self();
+        $image = new self($id);
         $image->file = $file;
         $image->author = $author;
 

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -47,12 +48,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Project
 {
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      */
     protected $id;
 
@@ -145,15 +144,13 @@ class Project
      */
     protected $updatedAt;
 
-    public function __construct()
+    public function __construct(UuidInterface $id)
     {
+        $this->id = $id;
         $this->teams = new ArrayCollection();
     }
 
-    /**
-     * @return Uuid|null
-     */
-    public function getId(): ?Uuid
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Entity/Rating.php
+++ b/src/Entity/Rating.php
@@ -14,6 +14,7 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -64,12 +65,10 @@ class Rating implements ThoughtInterface
     ];
 
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      *
      * @Groups({"RatingRead"})
      */
@@ -131,14 +130,15 @@ class Rating implements ThoughtInterface
      */
     protected $createdAt;
 
-    public function __construct(string $value = self::RATING_LIKE)
+    public function __construct(UuidInterface $id, string $value = self::RATING_LIKE)
     {
         Assertion::inArray($value, static::SUPPORTED_RATINGS, 'Review value "%s" is not among valid values: %s');
 
+        $this->id = $id;
         $this->value = $value;
     }
 
-    public function getId(): ?Uuid
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Entity/SecurityRole.php
+++ b/src/Entity/SecurityRole.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Serializer\Annotation\Groups;
 
@@ -35,12 +36,10 @@ use Symfony\Component\Serializer\Annotation\Groups;
 class SecurityRole extends Role
 {
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      *
      * @Groups({"SecurityRoleRead"})
      */
@@ -75,19 +74,15 @@ class SecurityRole extends Role
      */
     protected $users;
 
-    /**
-     * SecurityRole constructor.
-     *
-     * @param string $role
-     */
-    public function __construct(string $role)
+    public function __construct(UuidInterface $id, string $role)
     {
         parent::__construct($role);
+        $this->id = $id;
         $this->role = $role;
         $this->users = new ArrayCollection();
     }
 
-    public function getId(): ?Uuid
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -9,6 +9,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -47,12 +48,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Tag
 {
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      *
      * @Groups({"TagRead"})
      */
@@ -70,7 +69,7 @@ class Tag
     protected $code;
 
     /**
-     * @var null|string the name of the tag
+     * @var string the name of the tag
      *
      * @ORM\Column(type="string", nullable=false)
      *
@@ -83,33 +82,26 @@ class Tag
      */
     protected $name;
 
-    /**
-     * @return null|Uuid
-     */
-    public function getId(): ?Uuid
+    public function __construct(UuidInterface $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): UuidInterface
     {
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
     public function getCode(): string
     {
         return $this->code;
     }
 
-    /**
-     * @return null|string
-     */
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
     public function setName(string $name): void
     {
         $this->name = $name;
@@ -117,6 +109,6 @@ class Tag
 
     public function __toString(): string
     {
-        return (string) $this->name;
+        return $this->name;
     }
 }

--- a/src/Entity/Team.php
+++ b/src/Entity/Team.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -46,12 +47,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Team
 {
     /**
-     * @var Uuid
+     * @var UuidInterface
      *
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
      *
      * @Groups({"TeamRead"})
      */
@@ -104,13 +103,14 @@ class Team
      */
     protected $users;
 
-    public function __construct()
+    public function __construct(UuidInterface $id)
     {
+        $this->id = $id;
         $this->children = new ArrayCollection();
         $this->users = new ArrayCollection();
     }
 
-    public function getId(): ?Uuid
+    public function getId(): UuidInterface
     {
         return $this->id;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -231,12 +231,9 @@ class User implements UserInterface, FOSUserInterface
      */
     private $superAdmin;
 
-    /**
-     * User constructor.
-     */
-    public function __construct()
+    public function __construct(UuidInterface $id)
     {
-        $this->id = Uuid::uuid4();
+        $this->id = $id;
         $this->enabled = false;
         $this->superAdmin = false;
         $this->securityRoles = new ArrayCollection();

--- a/src/Security/User/JWTUser.php
+++ b/src/Security/User/JWTUser.php
@@ -14,9 +14,9 @@ final class JWTUser implements UserInterface, JWTUserInterface
     private $username;
     private $roles;
 
-    public function __construct(string $id, string $username, array $roles)
+    public function __construct(UuidInterface $id, string $username, array $roles)
     {
-        $this->id = Uuid::fromString($id);
+        $this->id = $id;
         $this->username = $username;
         $this->roles = $roles;
     }
@@ -27,7 +27,7 @@ final class JWTUser implements UserInterface, JWTUserInterface
     public static function createFromPayload($username, array $payload): self
     {
         return new self(
-            $payload['id'],
+            $payload['id'] instanceof UuidInterface ? $payload['id'] : Uuid::fromString($payload['id']),
             $username,
             $payload['roles']
         );

--- a/src/Serializer/AdminContextBuilder.php
+++ b/src/Serializer/AdminContextBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Serializer;
 
-use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
 use App\Serializer\Group\Factory\AdminSerializerGroupFactory;
 use DomainException;
@@ -13,27 +12,10 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class AdminContextBuilder implements SerializerContextBuilderInterface
 {
-    /**
-     * @var \ApiPlatform\Core\Serializer\SerializerContextBuilderInterface
-     */
     private $decorated;
-
-    /**
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
-     */
     private $authorizationChecker;
-
-    /**
-     * @var \App\Serializer\Group\Factory\AdminSerializerGroupFactory
-     */
     private $adminSerializerGroupFactory;
 
-    /**
-     * AdminContextBuilder constructor.
-     *
-     * @param \ApiPlatform\Core\Serializer\SerializerContextBuilderInterface               $decorated
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker
-     */
     public function __construct(SerializerContextBuilderInterface $decorated, AuthorizationCheckerInterface $authorizationChecker, AdminSerializerGroupFactory $adminSerializerGroupFactory)
     {
         $this->decorated = $decorated;
@@ -42,16 +24,7 @@ final class AdminContextBuilder implements SerializerContextBuilderInterface
     }
 
     /**
-     * Creates a serialization context from a Request.
-     *
-     * @param Request    $request
-     * @param bool       $normalization       true | false = denormalization
-     * @param array|null $extractedAttributes
-     *
-     * @throws RuntimeException
-     * @throws \DomainException
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null): array
     {

--- a/src/Serializer/UuidContextBuilder.php
+++ b/src/Serializer/UuidContextBuilder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Serializer;
+
+use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+
+final class UuidContextBuilder implements SerializerContextBuilderInterface
+{
+    private $decorated;
+
+    public function __construct(SerializerContextBuilderInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null): array
+    {
+        $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);
+
+        if (!$normalization && 'POST' === $request->getMethod()) {
+            $context['default_constructor_arguments'][$context['resource_class']]['id'] = Uuid::uuid4();
+        }
+
+        return $context;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -197,6 +197,9 @@
     "myclabs/deep-copy": {
         "version": "1.7.0"
     },
+    "namshi/jose": {
+        "version": "7.2.3"
+    },
     "nelmio/cors-bundle": {
         "version": "1.5.3"
     },

--- a/tests/Security/User/JWTUserTest.php
+++ b/tests/Security/User/JWTUserTest.php
@@ -14,13 +14,13 @@ class JWTUserTest extends TestCase
     public function testCreate(): void
     {
         $username = 'username';
-        $id = Uuid::uuid4()->toString();
+        $id = Uuid::uuid4();
         $roles = [UserInterface::ROLE_USER];
 
         $user = new JWTUser($id, $username, $roles);
 
         $this->assertSame($username, $user->getUsername());
-        $this->assertSame($id, $user->getId()->toString());
+        $this->assertSame($id, $user->getId());
         $this->assertSame($roles, $user->getRoles());
 
         $this->assertSame('', $user->getPassword());
@@ -40,14 +40,30 @@ class JWTUserTest extends TestCase
 
         $this->assertSame($username, $user->getUsername());
         $this->assertSame($payload['id'], $user->getId()->toString());
+        $this->assertNotSame($payload['id'], $user->getId());
+        $this->assertSame($payload['roles'], $user->getRoles());
+    }
+
+    public function testCreateFromPayloadWithUuidObject(): void
+    {
+        $username = 'username';
+        $payload = [
+            'id' => Uuid::uuid4(),
+            'roles' => [UserInterface::ROLE_USER],
+        ];
+
+        $user = JWTUser::createFromPayload($username, $payload);
+
+        $this->assertSame($username, $user->getUsername());
+        $this->assertSame($payload['id'], $user->getId());
         $this->assertSame($payload['roles'], $user->getRoles());
     }
 
     public function testIsUser(): void
     {
         $username = 'username';
-        $userId = Uuid::uuid4()->toString();
-        $userTwoId = Uuid::uuid4()->toString();
+        $userId = Uuid::uuid4();
+        $userTwoId = Uuid::uuid4();
         $roles = [UserInterface::ROLE_USER];
 
         $user = new JWTUser($userId, $username, $roles);

--- a/tests/Serializer/UuidContextBuilderTest.php
+++ b/tests/Serializer/UuidContextBuilderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Serializer;
+
+use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
+use App\Serializer\UuidContextBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class UuidContextBuilderTest extends TestCase
+{
+    /**
+     * @var SerializerContextBuilderInterface|ObjectProphecy
+     */
+    private $decoratedProphecy;
+
+    /**
+     * @var UuidContextBuilder
+     */
+    private $uuidContextBuilder;
+
+    protected function setUp()
+    {
+        $this->decoratedProphecy = $this->prophesize(SerializerContextBuilderInterface::class);
+
+        /** @var SerializerContextBuilderInterface $decoratedMock */
+        $decoratedMock = $this->decoratedProphecy->reveal();
+
+        $this->uuidContextBuilder = new UuidContextBuilder($decoratedMock);
+    }
+
+    public function testNonDenormalizationPostRequest(): void
+    {
+        $request = new Request();
+        $normalization = true;
+        $extractedAttributes = null;
+        $context = [];
+
+        $this->decoratedProphecy->createFromRequest($request, $normalization, $extractedAttributes)->willReturn($context)->shouldBeCalled();
+
+        $this->assertSame($context, $this->uuidContextBuilder->createFromRequest($request, $normalization, $extractedAttributes));
+    }
+
+    public function testDenormalizationOnPost(): void
+    {
+        $request = new Request();
+        $request->setMethod('POST');
+        $normalization = false;
+        $extractedAttributes = null;
+
+        $decoratedContext = [
+            'resource_class' => 'TestClass',
+        ];
+
+        $this->decoratedProphecy->createFromRequest($request, $normalization, $extractedAttributes)->willReturn($decoratedContext)->shouldBeCalled();
+
+        $context = $this->uuidContextBuilder->createFromRequest($request, $normalization, $extractedAttributes);
+        $this->assertSame($decoratedContext['resource_class'], $context['resource_class']);
+        $this->assertInstanceOf(UuidInterface::class, $context['default_constructor_arguments'][$decoratedContext['resource_class']]['id']);
+    }
+}


### PR DESCRIPTION
Uuid object now can be passed via __constructor thanks to improvement of Serializer component in
Symfony 4.1